### PR TITLE
Podspec update to meet cocoapods validations

### DIFF
--- a/ios/RNChangeIcon.podspec
+++ b/ios/RNChangeIcon.podspec
@@ -1,24 +1,23 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "../package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "RNChangeIcon"
-  s.version      = "1.0.0"
-  s.summary      = "RNChangeIcon"
+  s.version      = package["version"]
+  s.summary      = package["description"]
   s.description  = <<-DESC
                   RNChangeIcon
                    DESC
-  s.homepage     = ""
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.homepage     = package["repository"]["baseUrl"]
+  s.license      = package["license"]
+  s.author       = { "author" => package["author"]["email"] }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNChangeIcon.git", :tag => "master" }
-  s.source_files  = "RNChangeIcon/**/*.{h,m}"
+  s.source       = { :git => "#{package["repository"]["baseUrl"]}.git", :tag => "#{s.version}" }
+
+  s.source_files = "RNChangeIcon/**/*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
-
 end
-
   

--- a/ios/RNChangeIcon.podspec
+++ b/ios/RNChangeIcon.podspec
@@ -6,10 +6,8 @@ Pod::Spec.new do |s|
   s.name         = "RNChangeIcon"
   s.version      = package["version"]
   s.summary      = package["description"]
-  s.description  = <<-DESC
-                  RNChangeIcon
-                   DESC
-  s.homepage     = package["repository"]["baseUrl"]
+  s.description  = package["description"]
+  s.homepage     = package["homepage"]
   s.license      = package["license"]
   s.author       = { "author" => package["author"]["email"] }
   s.platform     = :ios, "7.0"


### PR DESCRIPTION
With RN 0.60 the default linking flow is [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) with Cocoapods.

`pod install` was giving an error and some warning because the podspec missing attributes. This PR fixes it.