### PR TITLE
Change source_files in podspec

### DIFF
--- a/ios/RNChangeIcon.podspec
+++ b/ios/RNChangeIcon.podspec
@@ -13,9 +13,9 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { :git => "#{package["repository"]["baseUrl"]}.git", :tag => "#{s.version}" }
 
-  s.source_files = "RNChangeIcon/**/*.{h,m}"
+  s.source_files = "*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"
 end
-  
+


### PR DESCRIPTION
In react native 0.60, when trying to change the icon in iOS, I get an error of `TypeError: Cannot read property 'changeIcon' of undefined`.  I updated the source files of the podspec to the correct directory