### PR TITLE
iOS: actually reject the promise if setAlternateIconName fails

### DIFF
--- a/ios/ChangeIcon.swift
+++ b/ios/ChangeIcon.swift
@@ -13,7 +13,12 @@ class ChangeIcon: NSObject {
             reject("Error", "Icon already in use", nil)
             return
         }
-        resolve(true)
-        UIApplication.shared.setAlternateIconName(iconName)
+        UIApplication.shared.setAlternateIconName(iconName, completionHandler: { (error) -> Void in
+            if error == nil {
+                resolve(true)
+            } else {
+                reject("Error", "Unable to change the icon", error)
+            }
+        })
     }
 }


### PR DESCRIPTION
Currently, the code resolves the promise even before `setAlternateIconName` resolves.

It would be more robust to actually reject the promise if `setAlternateIconName` fails, using the completion handler [as documented](https://developer.apple.com/documentation/uikit/uiapplication/2806818-setalternateiconname#declaration).