### PR TITLE
iOS:Explicitly initialize in background thread

### DIFF
--- a/ios/ChangeIcon.swift
+++ b/ios/ChangeIcon.swift
@@ -21,4 +21,8 @@ class ChangeIcon: NSObject {
         resolve(true)
         UIApplication.shared.setAlternateIconName(iconName)
     }
+
+    @objc static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
 }


### PR DESCRIPTION
This module has been very helpful. Thanks a lot.😊
I was always getting warnings because it didn't specify whether the initialization of the swift class should be done in the main thread or the background thread.
Therefore, I have explicitly specified that it should be done in the background thread.

<img src="https://user-images.githubusercontent.com/43626886/121659792-9c12e800-cadd-11eb-8d9c-ac7e2e74c025.jpg" width=300>
