### PR TITLE
Fix: Added support for changing the icon more than once on android

### DIFF
--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.kt
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.kt
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 
 class ChangeIconModule(reactContext: ReactApplicationContext, private val packageName: String) : ReactContextBaseJavaModule(reactContext), Application.ActivityLifecycleCallbacks {
-    private var classToKill: String = ""
+    private var classesToKill: MutableList<String> = ArrayList()
     private var iconChanged: Boolean = false;
     private var componentClass: String = ""
     override fun getName(): String {
@@ -38,7 +38,7 @@ class ChangeIconModule(reactContext: ReactApplicationContext, private val packag
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
             PackageManager.DONT_KILL_APP
         )
-        classToKill = componentClass;
+        classesToKill.add(componentClass)
         componentClass = activeClass
         activity.application.registerActivityLifecycleCallbacks(this)
         iconChanged = true;
@@ -50,11 +50,14 @@ class ChangeIconModule(reactContext: ReactApplicationContext, private val packag
           if (activity == null) {
             return
           }
-          activity.packageManager.setComponentEnabledSetting(
-            ComponentName(packageName, classToKill),
-            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            PackageManager.DONT_KILL_APP
-          )
+          for (c in classesToKill) {
+            activity.packageManager.setComponentEnabledSetting(
+                ComponentName(packageName, c),
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.DONT_KILL_APP
+            )
+          }
+          classesToKill.clear()
           iconChanged = false;
         }
     }

--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.kt
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.kt
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 
 class ChangeIconModule(reactContext: ReactApplicationContext, private val packageName: String) : ReactContextBaseJavaModule(reactContext), Application.ActivityLifecycleCallbacks {
-    private var classesToKill: MutableList<String> = ArrayList()
+    private var classesToKill: MutableList<String> = mutableListOf<String>()
     private var iconChanged: Boolean = false;
     private var componentClass: String = ""
     override fun getName(): String {
@@ -50,9 +50,9 @@ class ChangeIconModule(reactContext: ReactApplicationContext, private val packag
           if (activity == null) {
             return
           }
-          for (c in classesToKill) {
+          classesToKill.forEach {
             activity.packageManager.setComponentEnabledSetting(
-                ComponentName(packageName, c),
+                ComponentName(packageName, it),
                 PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
                 PackageManager.DONT_KILL_APP
             )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-change-icon",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Change application icon programmatically in React-Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -120,7 +120,10 @@
       ]
     }
   },
-  "eslintIgnore": ["node_modules/", "lib/"],
+  "eslintIgnore": [
+    "node_modules/",
+    "lib/"
+  ],
   "prettier": {
     "quoteProps": "consistent",
     "singleQuote": true,
@@ -131,6 +134,10 @@
   "@react-native-community/bob": {
     "source": "src",
     "output": "lib",
-    "targets": ["commonjs", "module", "typescript"]
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
   }
 }


### PR DESCRIPTION
When working with this package, I ran into a defect on android that caused multiple icons to be displayed when you hit the **changeIcon** method more than once before putting the app into the background.

In reviewing the code, it looked like the root cause was related to only ending one of the active activities after attempting to apply multiple icons.

I'm new to Kotlin and how you've composed this library, feel free to let me know if this solution is incorrect.

Thanks,
Max