### PR TITLE
feat: add error return if icon invalid for Android

### DIFF
--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.kt
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.kt
@@ -32,12 +32,17 @@ class ChangeIconModule(reactContext: ReactApplicationContext, private val packag
             promise.reject("Icon already in use.")
             return
         }
-        promise.resolve(true)
-        activity.packageManager.setComponentEnabledSetting(
-            ComponentName(packageName, activeClass),
-            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-            PackageManager.DONT_KILL_APP
-        )
+        try {
+            activity.packageManager.setComponentEnabledSetting(
+                ComponentName(packageName, activeClass),
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                PackageManager.DONT_KILL_APP
+            )
+            promise.resolve(true)
+        } catch (e: Exception) {
+            promise.reject("Invalid Icon")
+            return
+        }
         classesToKill.add(componentClass)
         componentClass = activeClass
         activity.application.registerActivityLifecycleCallbacks(this)


### PR DESCRIPTION
Currently, Android will throw red screen error (Equivalent to app crash in production) when the icon passed into `changeIcon()` is invalid. This is because the process will fail at `setComponentEnabledSetting()`. 

Wrapping the function in `try catch` block allow us to reject the promise and allow developers to handle the situation accordingly in RN.