### PR TITLE
feat: add getCurrentIcon and isAvailable methods on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,17 @@ protected List<ReactPackage> getPackages() {
 Now you can use the following code to change application icon:
 
 ```javascript
-import { changeIcon } from 'react-native-change-icon';
+import { changeIcon, getCurrentIcon, isAvailable } from 'react-native-change-icon';
 
 // Pass the name of icon to be enabled
 changeIcon('iconname');
+
+// Only iOS. Gets the application's current icon name
+getCurrentIcon();
+
+// Only iOS. Determines if the platform has the capabilities to use `changeIcon`
+isAvailable();
+
 ```
 
 `changeIcon` function returns a promise. The promise is resolved only when the icon is changed.

--- a/ios/ChangeIcon.m
+++ b/ios/ChangeIcon.m
@@ -4,4 +4,8 @@
 
 RCT_EXTERN_METHOD(changeIcon:(NSString *)iconName withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getCurrentIcon:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isAvailable:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/ChangeIcon.swift
+++ b/ios/ChangeIcon.swift
@@ -23,4 +23,20 @@ class ChangeIcon: NSObject {
             UIApplication.shared.setAlternateIconName(iconName)
         }
     }
+    
+    @available(iOS 10.3, *)
+    @objc(getCurrentIcon:withRejecter:)
+    func getCurrentIcon(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+        var iconName: String? = nil
+        if UIApplication.shared.supportsAlternateIcons {
+            iconName = UIApplication.shared.alternateIconName
+        }
+        resolve(iconName);
+    }
+    
+    @available(iOS 10.3, *)
+    @objc(isAvailable:withRejecter:)
+    func isAvailable(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+        resolve(UIApplication.shared.supportsAlternateIcons)
+    }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,4 +3,10 @@ import { NativeModules } from 'react-native';
 const changeIcon = (iconName: string): Promise<string> =>
   NativeModules.ChangeIcon.changeIcon(iconName);
 
-export { changeIcon };
+const getCurrentIcon = (): Promise<string | null> =>
+  NativeModules.ChangeIcon.getCurrentIcon();
+
+const isAvailable = (): Promise<boolean> =>
+  NativeModules.ChangeIcon.isAvailable();
+
+export { changeIcon, getCurrentIcon, isAvailable };


### PR DESCRIPTION
 :rocket: Added getCurrentIcon and isAvailable methods on ios

```js
import { getCurrentIcon, isAvailable } from 'react-native-change-icon';

// Gets the application's current icon name
getCurrentIcon: () => Promise<string | null>

// Determines if the platform has the capabilities to use `changeIcon`
isAvailable: () => Promise<boolean>
```