### PR TITLE
fix: replace ICON_INVALID text with original error and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 [![npm version](https://badge.fury.io/js/react-native-change-icon.svg)](https://badge.fury.io/js/react-native-change-icon)
 
 Change Application Icon Programmatically.
+
 - [x] iOS
 - [x] Android
 
 ## Getting started
 
 `$ npm i react-native-change-icon`
+
+## Link native code
+
+`$ cd ios && pod install`
 
 ## Usage
 
@@ -38,6 +43,7 @@ Change Application Icon Programmatically.
 ![Android Directory](images/Android_Icons.png)
 
 2. Modify your `AndroidManifest.xml` file's `<application>` tag as following:
+
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example">
@@ -81,18 +87,19 @@ Change Application Icon Programmatically.
 
 </manifest>
 ```
+
 You can create more `<activity-alias>` tags to make more alternate icons.
-*Note that the name in <activity-alias> should be "com.{package_name}.MainActivity%", where `%` is the icon name.*
+_Note that the name in <activity-alias> should be "com.{package_name}.MainActivity%", where `%` is the icon name._
 
 **Note that all the icon names must be in lowercase and only limited to alphabets `a-z`**
 
 Now you can use the following code to change application icon:
 
 ```javascript
-import { changeIcon, getIcon } from 'react-native-change-icon';
+import { changeIcon, getIcon } from "react-native-change-icon";
 
 // Pass the name of icon to be enabled
-changeIcon('iconname');
+changeIcon("iconname");
 
 // Get the icon currently enabled
 getIcon();

--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -79,7 +79,7 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
             );
             promise.resolve(enableIcon);
         } catch (Exception e) {
-            promise.reject("ICON_INVALID");
+            promise.reject(e);
             return;
         }
         this.classesToKill.add(this.componentClass);


### PR DESCRIPTION
I was trying out this package and faced some issues so I thought to address those.

**Issues:**
Android:
- I had an error in my `AndroidManifest.xml` file for the package name but in the log, I was getting "ICON_INVALID". 
solution - Replace "ICON_INVALID" with the original error.

ios:
- I wasn't able to change my icon and was constantly getting not able to find `changeIcon` because I forgot to do pod install as it wasn't mentioned in the docs.
solution - added a step for pod install in the docs.

Thanks for this great package :)  @skb1129 .

 