### PR TITLE
Fix #70, correctly handling the case where the current compentClass ends with MainActivity

### DIFF
--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -47,9 +47,18 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
         if (this.componentClass.isEmpty()) {
             this.componentClass = activity.getComponentName().getClassName();
         }
-        String currentIcon = this.componentClass.split("MainActivity")[1];
-        promise.resolve(currentIcon.isEmpty() ? "default" : currentIcon);
-        return;
+        if (this.componentClass.endsWith("MainActivity")) {
+            promise.resolve("default");
+            return;
+        }
+        String[] parts = this.componentClass.split("MainActivity");
+        if (parts.length != 2) {
+            promise.reject("UNEXPECTED_COMPONENT_CLASS: " + this.componentClass);
+            return;
+        }
+
+        String currentIcon = parts[1];
+        promise.resolve(currentIcon);
     }
 
     @ReactMethod
@@ -59,7 +68,7 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
             promise.reject("ACTIVITY_NOT_FOUND");
             return;
         }
-        if (enableIcon.isEmpty()) {
+        if (enableIcon == null || enableIcon.isEmpty()) {
             promise.reject("EMPTY_ICON_STRING");
             return;
         }


### PR DESCRIPTION
Java was throwing an exception.
I also guarded against `changeIcon(null)`, which also resulted in a native-side crash, instead of rejecting the promise.