### PR TITLE
fix: change ArrayList to HashSet in android module

### DIFF
--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -14,14 +14,14 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @ReactModule(name = "ChangeIcon")
 public class ChangeIconModule extends ReactContextBaseJavaModule implements Application.ActivityLifecycleCallbacks {
     public static final String NAME = "ChangeIcon";
     private final String packageName;
-    private final List<String> classesToKill = new ArrayList<>();
+    private final Set<String> classesToKill = new HashSet<>();
     private Boolean iconChanged = false;
     private String componentClass = "";
 
@@ -89,9 +89,9 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
         }
         this.classesToKill.add(this.componentClass);
         this.componentClass = activeClass;
+        this.classesToKill.removeIf(cls -> cls.equals(activeClass));
         activity.getApplication().registerActivityLifecycleCallbacks(this);
         iconChanged = true;
-        activity.finish();
     }
 
     private void completeIconChange() {


### PR DESCRIPTION
Hi, I have a suggestion!

It seems that the version increase of react-native-change-icon to 5.0.0, the following code was added, and it's causing the app to finish every time changeIcon is called

https://github.com/skb1129/react-native-change-icon/blob/d3a945159aa9fab3f79da9b6419b55eeac6bea97/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java#L89-L96

And, there appears to be an issue with the logic to disable components in the Android Module. For example, when switching between A (aliased-activity) and B (aliased-activity) repeatedly, it seems that both Alias-Activities are being disabled in the ArrayList (when activity.finish() is removed).

So, I tried modifying the code like in this PR. What do you think?