### PR TITLE
SS Adds ability to use unsafe suppress alert option for iOS only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 local.properties
 .idea/
 .gradle/
+**/xcuserdata/

--- a/NativeChangeIcon.ts
+++ b/NativeChangeIcon.ts
@@ -1,10 +1,14 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
+export type IconChangeOptions = {
+  /** iOS only - prevents alert from appearing */
+  useUnsafeSupressAlert?: boolean;
+}
 export interface Spec extends TurboModule {
     readonly getConstants: () => {};
-    changeIcon: (iconName?: string) => Promise<string>;
-    resetIcon: () => Promise<string>;
+    changeIcon: (iconName?: string, options?: IconChangeOptions) => Promise<string>;
+    resetIcon: (optionsv: IconChangeOptions) => Promise<string>;
     getIcon: () => Promise<string>;
 }
 

--- a/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
+++ b/android/src/main/java/com/reactnativechangeicon/ChangeIconModule.java
@@ -12,6 +12,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 
 import java.util.HashSet;
@@ -60,7 +61,7 @@ public class ChangeIconModule extends ReactContextBaseJavaModule implements Appl
     }
 
     @ReactMethod
-    public void changeIcon(String iconName, Promise promise) {
+    public void changeIcon(String iconName, ReadableMap params, Promise promise) {
         final Activity activity = getCurrentActivity();
         final String activityName = activity.getComponentName().getClassName();
         if (activity == null) {

--- a/ios/ChangeIcon.mm
+++ b/ios/ChangeIcon.mm
@@ -18,8 +18,10 @@ RCT_REMAP_METHOD(getIcon, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCT
     });
 }
 
-RCT_REMAP_METHOD(changeIcon, iconName:(NSString *)iconName resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_REMAP_METHOD(changeIcon, iconName:(NSString *)iconName options:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_main_queue(), ^{
+      
+        Bool useUnsafeSuppressAlert = [[options objectForKey: @"useUnsafeSuppressAlert"] boolValue];
         NSError *error = nil;
 
         if ([[UIApplication sharedApplication] supportsAlternateIcons] == NO) {
@@ -42,10 +44,28 @@ RCT_REMAP_METHOD(changeIcon, iconName:(NSString *)iconName resolver:(RCTPromiseR
             newIconName = iconName;
             resolve(newIconName);
         }
-
-        [[UIApplication sharedApplication] setAlternateIconName:newIconName completionHandler:^(NSError * _Nullable error) {
-            return;
-        }];
+        
+        if (useUnsafeSuppressAlert == true) {
+            @try {
+                typedef void (*setAlternateIconName)(NSObject *, SEL, NSString *, void (^)(NSError *));
+                NSString *selectorString = @"_setAlternateIconName:completionHandler:";
+                SEL selector = NSSelectorFromString(selectorString);
+                IMP imp = [[UIApplication sharedApplication] methodForSelector:selector];
+                setAlternateIconName method = (setAlternateIconName)imp;
+                method([UIApplication sharedApplication], selector, iconName, ^(NSError *error) {});
+            }
+            @catch {
+              // fallback on safe method
+              [[UIApplication sharedApplication] setAlternateIconName:newIconName completionHandler:^(NSError * _Nullable error) {
+                return;
+              }];
+            }
+        } else {
+          [[UIApplication sharedApplication] setAlternateIconName:newIconName completionHandler:^(NSError * _Nullable error) {
+              return;
+          }];
+        }
+        
     });
 }
 

--- a/ios/ChangeIcon.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/ChangeIcon.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { NativeModules } from "react-native";
 
-export const changeIcon = (iconName?: string): Promise<string> => NativeModules.ChangeIcon.changeIcon(iconName);
-export const resetIcon = () => changeIcon();
+export type IconChangeOptions = {
+  /** iOS only - prevents alert from appearing */
+  useUnsafeSupressAlert?: boolean;
+}
+
+export const changeIcon = (iconName?: string, options?: IconChangeOptions): Promise<string> => NativeModules.ChangeIcon.changeIcon(iconName, options);
+export const resetIcon = (options?: IconChangeOptions) => changeIcon(undefined, options);
 export const getIcon = (): Promise<string> => NativeModules.ChangeIcon.getIcon();


### PR DESCRIPTION
Need to 

- [ ] run some tests first, but this allow devs to use the unsafe method that does not force an alert popup. 
- [x] I need to also put it inside of a try catch
- [x] update android so the code doesnt break