### PR TITLE
Patch entry for new arch

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,0 @@
-export declare const changeIcon: (iconName?: string) => Promise<string>;
-export declare const resetIcon: () => Promise<string>;
-export declare const getIcon: () => Promise<string>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,0 @@
-import { NativeModules } from "react-native";
-export const changeIcon = (iconName) => NativeModules.ChangeIcon.changeIcon(iconName);
-export const resetIcon = () => changeIcon();
-export const getIcon = () => NativeModules.ChangeIcon.getIcon();

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "title": "React Native Change Icon",
   "version": "5.0.0",
   "description": "Change application icon programmatically in React-Native.",
-  "main": "dist/index.js",
-  "source": "src/index.ts",
-  "react-native": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "NativeChangeIcon.ts",
+  "source": "NativeChangeIcon.ts",
+  "react-native": "NativeChangeIcon.ts",
+  "types": "NativeChangeIcon.ts",
   "files": [
     "android",
     "ios",
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "react-native": "*"
   },
-  "packageManager": "^yarn@1.22.19",
+  "packageManager": "yarn@1.22.22",
   "codegenConfig": {
     "name": "RNChangeIconSpec",
     "type": "all",


### PR DESCRIPTION
When trying to import it's pointing at a dist folder that has not been rebuilt and contains old references. 
**Fix**
- Remove dist folder
- Rename entry files for package.json